### PR TITLE
feat: Aligned implementation of 'pure'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ implementations for commonly used class instances.
 To install the latest version of `do` from [`hex`](https://hex.pm/packages/do),
 add `do` to the `deps` in your rebar config file:
 
-    {do, "1.2.2"}
+    {do, "1.3.0"}
 
 ### What's in the box
 

--- a/doc/do.html
+++ b/doc/do.html
@@ -40,6 +40,7 @@
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#bind-2">bind/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#do-2">do/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#get_monads-0">get_monads/0</a></td><td></td></tr>
+<tr><td valign="top"><a href="#pure-1">pure/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#register_monad-1">register_monad/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#then-2">then/2</a></td><td></td></tr>
 </table>
@@ -61,6 +62,12 @@
 <h3 class="function"><a name="get_monads-0">get_monads/0</a></h3>
 <div class="spec">
 <p><tt>get_monads() -&gt; [atom()]</tt><br></p>
+<p> </p>
+</div>
+
+<h3 class="function"><a name="pure-1">pure/1</a></h3>
+<div class="spec">
+<p><tt>pure(A) -&gt; <a href="#type-monad">monad</a>(A) | A</tt><br></p>
 <p> </p>
 </div>
 

--- a/doc/do_monad.html
+++ b/doc/do_monad.html
@@ -42,7 +42,6 @@
 <tr><td valign="top"><a href="#lift-2">lift/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#liftm-3">liftm/3</a></td><td></td></tr>
 <tr><td valign="top"><a href="#liftmz-3">liftmz/3</a></td><td></td></tr>
-<tr><td valign="top"><a href="#pure_with_ctx-1">pure_with_ctx/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#then-3">then/3</a></td><td></td></tr>
 </table>
 
@@ -69,12 +68,6 @@
 <h3 class="function"><a name="liftmz-3">liftmz/3</a></h3>
 <div class="spec">
 <p><tt>liftmz(F::function(), Thunks::[<a href="#type-fn">fn</a>(<a href="#type-monad">monad</a>(term()))], Mod::atom()) -&gt; <a href="#type-monad">monad</a>(term())</tt><br></p>
-<p> </p>
-</div>
-
-<h3 class="function"><a name="pure_with_ctx-1">pure_with_ctx/1</a></h3>
-<div class="spec">
-<p><tt>pure_with_ctx(Ctx) -&gt; any()</tt></p>
 <p> </p>
 </div>
 

--- a/include/do.hrl
+++ b/include/do.hrl
@@ -1,7 +1,6 @@
 %%%_* Macros ==================================================================
 -define(fmap(F, Functor),      do_functor:fmap(F, Functor)).
 
--define(pure(A),               (do_monad:pure_with_ctx(?do_internal_ctx))(A)).
 -define(sequence(Traversable), do_either:sequence(Traversable)).
 -define(lift(F),               do_either:lift(F)).
 -define(liftA2(A1, A2),        do_either:liftA2(A1, A2)).
@@ -9,6 +8,10 @@
 -define(do(Monad, Funs),       do:do(Monad, Funs)).
 -define(bind(F, Monad),        do:bind(F, Monad)).
 -define(then(F, Monad),        do:then(F, Monad)).
+-define(pure(A),               do:pure(A)).
+
+-define(thunk(A),              fun() -> A end).
+-define(f(F),                  ?thunk(F)).
 
 -define(liftm(F, A1),
         do_either:liftmz(F, [?f(A1)])).
@@ -28,9 +31,3 @@
         do_either:liftmz(F, [?f(A1), ?f(A2), ?f(A3), ?f(A4), ?f(A5), ?f(A6), ?f(A7), ?f(A8)])).
 -define(liftm(F, A1, A2, A3, A4, A5, A6, A7, A8, A9),
         do_either:liftmz(F, [?f(A1), ?f(A2), ?f(A3), ?f(A4), ?f(A5), ?f(A6), ?f(A7), ?f(A8), ?f(A9)])).
-
--define(thunk(A), fun() -> A end).
-
-%%%_* Macros Internal - May Change Any Time ===================================
--define(do_internal_ctx, element(2, process_info(self(), current_stacktrace))).
--define(f(F),            ?thunk(F)).

--- a/src/do.app.src
+++ b/src/do.app.src
@@ -1,6 +1,6 @@
 {application, do,
  [{description, "Monads, Functors and Do-Notation for Erlang"},
-  {vsn, "1.2.2"},
+  {vsn, "1.3.0"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
## About

- `?pure(A)` now returns `A` if not called in a monad context
- better implementation of `pure`
- cleanup