### PR TITLE
feat: Improved API for 'then' macro + refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ implementations for commonly used class instances.
 To install the latest version of `do` from [`hex`](https://hex.pm/packages/do),
 add `do` to the `deps` in your rebar config file:
 
-    {do, "1.5.0"}
+    {do, "1.6.0"}
 
 ### What's in the box
 

--- a/doc/do.html
+++ b/doc/do.html
@@ -41,7 +41,7 @@
 
 
 <h3 class="typedecl"><a name="type-maybe">maybe()</a></h3>
-<p><tt>maybe(A) = {ok, A} | error</tt></p>
+<p><tt>maybe(A) = {just, A} | nothing</tt></p>
 
 
 <h3 class="typedecl"><a name="type-monad">monad()</a></h3>
@@ -67,7 +67,7 @@
 
 <h3 class="function"><a name="do-2">do/2</a></h3>
 <div class="spec">
-<p><tt>do(Monad::<a href="#type-monad">monad</a>(A), Funs::[<a href="#type-fn">fn</a>(A, <a href="#type-monad">monad</a>(B)) | <a href="#type-fn">fn</a>(<a href="#type-monad">monad</a>(B))]) -&gt; <a href="#type-monad">monad</a>(B)</tt><br></p>
+<p><tt>do(Monad::<a href="#type-monad">monad</a>(A), Fs::[<a href="#type-fn">fn</a>(A, <a href="#type-monad">monad</a>(B)) | <a href="#type-fn">fn</a>(<a href="#type-monad">monad</a>(B))]) -&gt; <a href="#type-monad">monad</a>(B)</tt><br></p>
 <p> </p>
 </div>
 

--- a/doc/do_either.html
+++ b/doc/do_either.html
@@ -34,7 +34,7 @@
 
 
 <h3 class="typedecl"><a name="type-maybe">maybe()</a></h3>
-<p><tt>maybe(A) = {ok, A} | error</tt></p>
+<p><tt>maybe(A) = {just, A} | nothing</tt></p>
 
 
 <h3 class="typedecl"><a name="type-monad">monad()</a></h3>
@@ -49,7 +49,6 @@
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#bind-2">bind/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#do-2">do/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#fmap-2">fmap/2</a></td><td></td></tr>
-<tr><td valign="top"><a href="#is_instance-1">is_instance/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#lift-1">lift/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#liftA2-2">liftA2/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#liftm-2">liftm/2</a></td><td></td></tr>
@@ -76,12 +75,6 @@
 <h3 class="function"><a name="fmap-2">fmap/2</a></h3>
 <div class="spec">
 <p><tt>fmap(F::<a href="#type-fn">fn</a>(B, C), X2::<a href="#type-either">either</a>(A, B)) -&gt; <a href="#type-either">either</a>(A, C)</tt><br></p>
-<p> </p>
-</div>
-
-<h3 class="function"><a name="is_instance-1">is_instance/1</a></h3>
-<div class="spec">
-<p><tt>is_instance(X1::term()) -&gt; boolean()</tt><br></p>
 <p> </p>
 </div>
 

--- a/doc/do_list.html
+++ b/doc/do_list.html
@@ -34,7 +34,7 @@
 
 
 <h3 class="typedecl"><a name="type-maybe">maybe()</a></h3>
-<p><tt>maybe(A) = {ok, A} | error</tt></p>
+<p><tt>maybe(A) = {just, A} | nothing</tt></p>
 
 
 <h3 class="typedecl"><a name="type-monad">monad()</a></h3>
@@ -49,7 +49,6 @@
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#bind-2">bind/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#do-2">do/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#fmap-2">fmap/2</a></td><td></td></tr>
-<tr><td valign="top"><a href="#is_instance-1">is_instance/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#lift-1">lift/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#liftA2-2">liftA2/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#liftm-2">liftm/2</a></td><td></td></tr>
@@ -75,12 +74,6 @@
 <h3 class="function"><a name="fmap-2">fmap/2</a></h3>
 <div class="spec">
 <p><tt>fmap(F::<a href="#type-fn">fn</a>(A, B), List::[A]) -&gt; [B]</tt><br></p>
-<p> </p>
-</div>
-
-<h3 class="function"><a name="is_instance-1">is_instance/1</a></h3>
-<div class="spec">
-<p><tt>is_instance(Term::term()) -&gt; boolean()</tt><br></p>
 <p> </p>
 </div>
 

--- a/doc/do_maybe.html
+++ b/doc/do_maybe.html
@@ -34,7 +34,7 @@
 
 
 <h3 class="typedecl"><a name="type-maybe">maybe()</a></h3>
-<p><tt>maybe(A) = {ok, A} | error</tt></p>
+<p><tt>maybe(A) = {just, A} | nothing</tt></p>
 
 
 <h3 class="typedecl"><a name="type-monad">monad()</a></h3>
@@ -49,7 +49,6 @@
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#bind-2">bind/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#do-2">do/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#fmap-2">fmap/2</a></td><td></td></tr>
-<tr><td valign="top"><a href="#is_instance-1">is_instance/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#lift-1">lift/1</a></td><td></td></tr>
 <tr><td valign="top"><a href="#liftA2-2">liftA2/2</a></td><td></td></tr>
 <tr><td valign="top"><a href="#liftm-2">liftm/2</a></td><td></td></tr>
@@ -76,12 +75,6 @@
 <h3 class="function"><a name="fmap-2">fmap/2</a></h3>
 <div class="spec">
 <p><tt>fmap(F::<a href="#type-fn">fn</a>(A, B), X2::<a href="#type-maybe">maybe</a>(A)) -&gt; <a href="#type-maybe">maybe</a>(B)</tt><br></p>
-<p> </p>
-</div>
-
-<h3 class="function"><a name="is_instance-1">is_instance/1</a></h3>
-<div class="spec">
-<p><tt>is_instance(X1::term()) -&gt; boolean()</tt><br></p>
 <p> </p>
 </div>
 

--- a/doc/do_monad.html
+++ b/doc/do_monad.html
@@ -12,7 +12,7 @@
 <h1>Module do_monad</h1>
 <ul class="index"><li><a href="#description">Description</a></li><li><a href="#types">Data Types</a></li><li><a href="#index">Function Index</a></li><li><a href="#functions">Function Details</a></li></ul>The Monad Type Class.
 
-<p><b>This module defines the <tt>do_monad</tt> behaviour.</b><br> Required callback functions: <tt>bind/2</tt>, <tt>do/2</tt>, <tt>then/2</tt>, <tt>lift/1</tt>, <tt>liftm/2</tt>, <tt>is_instance/1</tt>.</p>
+<p><b>This module defines the <tt>do_monad</tt> behaviour.</b><br> Required callback functions: <tt>bind/2</tt>, <tt>do/2</tt>, <tt>then/2</tt>, <tt>lift/1</tt>, <tt>liftm/2</tt>.</p>
 
 <h2><a name="description">Description</a></h2>The Monad Type Class.
 <h2><a name="types">Data Types</a></h2>
@@ -30,7 +30,7 @@
 
 
 <h3 class="typedecl"><a name="type-maybe">maybe()</a></h3>
-<p><tt>maybe(A) = {ok, A} | error</tt></p>
+<p><tt>maybe(A) = {just, A} | nothing</tt></p>
 
 
 <h3 class="typedecl"><a name="type-monad">monad()</a></h3>
@@ -49,7 +49,7 @@
 
 <h3 class="function"><a name="do-3">do/3</a></h3>
 <div class="spec">
-<p><tt>do(Monad::<a href="#type-monad">monad</a>(A), Fs::[<a href="#type-fn">fn</a>(A, <a href="#type-monad">monad</a>(B)) | <a href="#type-fn">fn</a>(<a href="#type-monad">monad</a>(B))], Mods::[atom()]) -&gt; <a href="#type-monad">monad</a>(B)</tt><br></p>
+<p><tt>do(Monad::<a href="#type-monad">monad</a>(A), Fs::[<a href="#type-fn">fn</a>(A, <a href="#type-monad">monad</a>(B)) | <a href="#type-fn">fn</a>(<a href="#type-monad">monad</a>(B))], Mod::atom()) -&gt; <a href="#type-monad">monad</a>(B)</tt><br></p>
 <p> </p>
 </div>
 

--- a/doc/do_traversable.html
+++ b/doc/do_traversable.html
@@ -37,7 +37,7 @@
 
 
 <h3 class="typedecl"><a name="type-maybe">maybe()</a></h3>
-<p><tt>maybe(A) = {ok, A} | error</tt></p>
+<p><tt>maybe(A) = {just, A} | nothing</tt></p>
 
 
 <h3 class="typedecl"><a name="type-traversable">traversable()</a></h3>

--- a/include/do.hrl
+++ b/include/do.hrl
@@ -7,7 +7,7 @@
 -define(pure(A),               do:pure(A)).
 -define(do(Monad, Fs),         do:do(Monad, Fs)).
 -define(bind(Monad, F),        do:bind(Monad, F)).
--define(then(Monad, F),        do:then(Monad, F)).
+-define(then(Monad1, Monad2),  do:then(Monad1, ?f(Monad2))).
 
 -define(sequence(Traversable), do_either:sequence(Traversable)).
 -define(lift(F),               do_either:lift(F)).

--- a/include/do_types.hrl
+++ b/include/do_types.hrl
@@ -9,7 +9,7 @@
 
 -type either(A, B)   :: {error, A} | {ok, B}.
 
--type maybe(A)       :: {ok, A} | error.
+-type maybe(A)       :: {just, A} | nothing.
 
 -type traversable(A) :: [A] | map(A).
 

--- a/src/do.app.src
+++ b/src/do.app.src
@@ -1,6 +1,6 @@
 {application, do,
  [{description, "Monads, Functors and Do-Notation for Erlang"},
-  {vsn, "1.5.0"},
+  {vsn, "1.6.0"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/do_either.erl
+++ b/src/do_either.erl
@@ -20,8 +20,7 @@
                liftmz/2,
                pure/1,
                sequence/1,
-               then/2,
-               is_instance/1]).
+               then/2]).
 -export(?API).
 -ignore_xref(?API).
 
@@ -52,7 +51,7 @@ sequence(Eithers) -> do_traversable:sequence(Eithers, ?MODULE).
 bind(Either, F) when ?isF1(F) -> flat(fmap(F, Either)).
 
 -spec do(either(A, B), [fn(B, either(C, D)) | fn(either(C, D))]) -> either(A | C, D).
-do(Either, Fs) -> do_monad:do(Either, Fs, [?MODULE]).
+do(Either, Fs) -> do_monad:do(Either, Fs, ?MODULE).
 
 -spec lift(fn(A, B)) -> fn(monad(A), monad(B)).
 lift(F) -> do_monad:lift(F, ?MODULE).
@@ -65,11 +64,6 @@ liftmz(F, Eithers) -> do_monad:liftmz(F, Eithers, ?MODULE).
 
 -spec then(either(A, _), fn(either(B, C))) -> either(A | B, C).
 then(Either, F) -> do_monad:then(Either, F, ?MODULE).
-
--spec is_instance(_) -> boolean().
-is_instance({ok, _})    -> true;
-is_instance({error, _}) -> true;
-is_instance(_)          -> false.
 
 %%%_* internal ----------------------------------------------------------------
 flat({ok, {error, A}}) -> {error, A};

--- a/src/do_functor.erl
+++ b/src/do_functor.erl
@@ -23,7 +23,8 @@ functors(A) ->
   , fun(_) -> A end
   , {ok, A}
   , {error, reason}
-  , error].
+  , {just, A}
+  , nothing].
   
 preserve_identity_morphism_test() ->
   Id       = fun(Term) -> Term end,

--- a/src/do_list.erl
+++ b/src/do_list.erl
@@ -19,8 +19,7 @@
                liftm/2,
                pure/1,
                sequence/1,
-               then/2,
-               is_instance/1]).
+               then/2]).
 -export(?API).
 -ignore_xref(?API).
 
@@ -49,7 +48,7 @@ sequence(Lists) -> do_traversable:sequence(Lists, ?MODULE).
 bind(List, F) when ?isF1(F) -> flat(fmap(F, List)).
 
 -spec do([A], [fn(A, [B]) | fn([B])]) -> [B].
-do(List, Fs) -> do_monad:do(List, Fs, [?MODULE]).
+do(List, Fs) -> do_monad:do(List, Fs, ?MODULE).
 
 -spec lift(fn(A, B)) -> fn(monad(A), monad(B)).
 lift(F) -> do_monad:lift(F, ?MODULE).
@@ -59,9 +58,6 @@ liftm(F, Lists) -> do_monad:liftm(F, Lists, ?MODULE).
 
 -spec then(list(), fn([A])) -> [A].
 then(List, F) -> do_monad:then(List, F, ?MODULE).
-
--spec is_instance(_) -> boolean().
-is_instance(Term) -> is_list(Term).
 
 %%%_* internal ----------------------------------------------------------------
 flat(List) -> lists:concat(List).

--- a/src/do_maybe.erl
+++ b/src/do_maybe.erl
@@ -20,8 +20,7 @@
                liftmz/2,
                pure/1,
                sequence/1,
-               then/2,
-               is_instance/1]).
+               then/2]).
 -export(?API).
 -ignore_xref(?API).
 
@@ -33,16 +32,16 @@
 %%%_* Code ====================================================================
 %%%_* functor -----------------------------------------------------------------
 -spec fmap(fn(A, B), maybe(A)) -> maybe(B).
-fmap(F, {ok, A}) when ?isF1(F) -> {ok, F(A)};
-fmap(F, error)   when ?isF1(F) -> error.
+fmap(F, {just, A}) when ?isF1(F) -> {just, F(A)};
+fmap(F, nothing)   when ?isF1(F) -> nothing.
 
 %%%_* applicative -------------------------------------------------------------
 -spec liftA2(maybe(fn(A, B)), maybe(A)) -> maybe(B).
-liftA2({ok, F}, Maybe) when ?isF1(F) -> fmap(F, Maybe);
-liftA2(error, _)                     -> error.
+liftA2({just, F}, Maybe) when ?isF1(F) -> fmap(F, Maybe);
+liftA2(nothing, _)                     -> nothing.
 
 -spec pure(A) -> maybe(A).
-pure(A) -> {ok, A}.
+pure(A) -> {just, A}.
 
 -spec sequence(traversable(maybe(A))) -> maybe(traversable(A)).
 sequence(Maybes) -> do_traversable:sequence(Maybes, ?MODULE).
@@ -52,7 +51,7 @@ sequence(Maybes) -> do_traversable:sequence(Maybes, ?MODULE).
 bind(Maybe, F) when ?isF1(F) -> flat(fmap(F, Maybe)).
 
 -spec do(maybe(A), [fn(A, maybe(B)) | fn(maybe(B))]) -> maybe(B).
-do(Maybe, Fs) -> do_monad:do(Maybe, Fs, [?MODULE]).
+do(Maybe, Fs) -> do_monad:do(Maybe, Fs, ?MODULE).
 
 -spec lift(fn(A, B)) -> fn(monad(A), monad(B)).
 lift(F) -> do_monad:lift(F, ?MODULE).
@@ -66,68 +65,63 @@ liftmz(F, Maybes) -> do_monad:liftmz(F, Maybes, ?MODULE).
 -spec then(maybe(_), fn(maybe(A))) -> maybe(A).
 then(Maybe, F) -> do_monad:then(Maybe, F, ?MODULE).
 
--spec is_instance(_) -> boolean().
-is_instance({ok, _}) -> true;
-is_instance(error)   -> true;
-is_instance(_)       -> false.
-
 %%%_* internal ----------------------------------------------------------------
-flat({ok, error})   -> error;
-flat(error)         -> error;
-flat({ok, {ok, A}}) -> {ok, A}.
+flat({just, nothing})   -> nothing;
+flat(nothing)           -> nothing;
+flat({just, {just, A}}) -> {just, A}.
 
 %%%_* Tests ===================================================================
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
 pure_test() ->
-  ?assertEqual({ok, {ok, 3}}, pure({ok, 3})),
-  ?assertEqual({ok, 3},       pure(3)).
+  ?assertEqual({just, {just, 3}}, pure({just, 3})),
+  ?assertEqual({just, 3},       pure(3)).
 
 lift_test() ->
   F      = fun(A) -> A + 1 end,
   Lifted = lift(F),
-  ?assertEqual({ok, 2}, Lifted({ok, 1})),
-  ?assertEqual(error,   Lifted(error)).
+  ?assertEqual({just, 2}, Lifted({just, 1})),
+  ?assertEqual(nothing,   Lifted(nothing)).
 
 liftA2_test() ->
   F = fun(A) -> A + 1 end,
-  ?assertEqual({ok, 3}, liftA2({ok, F}, {ok, 2})),
-  ?assertEqual(error,   liftA2({ok, F}, error)),
-  ?assertEqual(error,   liftA2(error,   {ok, 2})),
-  ?assertEqual(error,   liftA2(error,   error)).
+  ?assertEqual({just, 3}, liftA2({just, F}, {just, 2})),
+  ?assertEqual(nothing,   liftA2({just, F}, nothing)),
+  ?assertEqual(nothing,   liftA2(nothing,   {just, 2})),
+  ?assertEqual(nothing,   liftA2(nothing,   nothing)).
 
 liftm_test() ->
   F = fun(A, B, C) -> A + B + C end,
-  ?assertEqual({ok, 4}, liftm(F, [{ok, 1}, {ok, 2}, {ok, 1}])),
-  ?assertEqual(error,   liftm(F, [{ok, 1}, error,   {ok, 1}])),
-  ?assertEqual(error,   liftm(F, [error,   {ok, 2}, {ok, 1}])),
-  ?assertEqual(error,   liftm(F, [error,   error,   {ok, 1}])).
+  ?assertEqual({just, 4}, liftm(F, [{just, 1}, {just, 2}, {just, 1}])),
+  ?assertEqual(nothing,   liftm(F, [{just, 1}, nothing,   {just, 1}])),
+  ?assertEqual(nothing,   liftm(F, [nothing,   {just, 2}, {just, 1}])),
+  ?assertEqual(nothing,   liftm(F, [nothing,   nothing,   {just, 1}])).
 
 liftmz_test() ->
   F = fun(A, B, C) -> A + B + C end,
-  ?assertEqual({ok, 4},         liftmz(F, [?thunk({ok, 1}), ?thunk({ok, 2}), ?thunk({ok, 1})])),
-  ?assertError(function_clause, liftmz(F, [{ok, 1}, ?thunk({ok, 1})])).
+  ?assertEqual({just, 4},       liftmz(F, [?thunk({just, 1}), ?thunk({just, 2}), ?thunk({just, 1})])),
+  ?assertError(function_clause, liftmz(F, [{just, 1}, ?thunk({just, 1})])).
 
 bind_test() ->
-  FOk    = fun(A) -> {ok, A + 1} end,
-  FError = fun(_) -> error end,
-  ?assertEqual({ok, 3}, bind({ok, 2},FOk)),
-  ?assertEqual(error,   bind(error, FOk)),
-  ?assertEqual(error,   bind({ok, 2}, FError)),
-  ?assertEqual(error,   bind(error, FError)).
+  Fjust    = fun(A) -> {just, A + 1} end,
+  Fnothing = fun(_) -> nothing end,
+  ?assertEqual({just, 3}, bind({just, 2},Fjust)),
+  ?assertEqual(nothing,   bind(nothing, Fjust)),
+  ?assertEqual(nothing,   bind({just, 2}, Fnothing)),
+  ?assertEqual(nothing,   bind(nothing, Fnothing)).
 
 sequence_test() ->
-  ?assertEqual({ok, [1, 2, 3]},         sequence([{ok, 1}, {ok, 2}, {ok, 3}])),
-  ?assertEqual(error,                   sequence([{ok, 1}, error, {ok, 3}])),
-  ?assertEqual({ok, #{a => 1, b => 2}}, sequence(#{a => {ok, 1}, b => {ok, 2}})),
-  ?assertEqual(error,                   sequence(#{a => {ok, 1}, b => error})).
+  ?assertEqual({just, [1, 2, 3]},         sequence([{just, 1}, {just, 2}, {just, 3}])),
+  ?assertEqual(nothing,                   sequence([{just, 1}, nothing, {just, 3}])),
+  ?assertEqual({just, #{a => 1, b => 2}}, sequence(#{a => {just, 1}, b => {just, 2}})),
+  ?assertEqual(nothing,                   sequence(#{a => {just, 1}, b => nothing})).
 
 do_test() ->
   Fun0 = fun() -> ?pure(5) end,
   Fun = fun(A) -> ?pure(A + 1) end,
-  ?assertEqual({ok, 4},  do({ok, 3}, [Fun])),
-  ?assertEqual({ok, 6},  do({ok, 3}, [Fun0, Fun])),
-  ?assertEqual(error,    do(error,   [Fun])).
+  ?assertEqual({just, 4},  do({just, 3}, [Fun])),
+  ?assertEqual({just, 6},  do({just, 3}, [Fun0, Fun])),
+  ?assertEqual(nothing,    do(nothing,   [Fun])).
 
 -endif.


### PR DESCRIPTION
changed syntax for `then` macro by automatically wrapping second argument in thunk.

before:

```erlang
?then({ok, 1}, fun() -> {ok, 2} end)
```

after:

```erlang
?then({ok, 1}, {ok, 2})
```

also changed `maybe` type to `{just, _} | nothing` and simplified implementation of monad `do` flow.